### PR TITLE
Crash fix

### DIFF
--- a/PDBParser.cpp
+++ b/PDBParser.cpp
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// Original author: Jake Shadle <jshadle@dice.se>
+// Original author: Jake Shadle <jake.shadle@frostbite.com>
 
 #include "PDBParser.h"
 
@@ -667,9 +667,9 @@ PDBParser::printBreakpadSymbols(FILE* of, const char* platform, FileMod* fileMod
 		DataPtr<char>			objectName;
 
 		Module(DataPtr<DBIModuleInfo>&& data, DataPtr<char>&& modName, DataPtr<char>&& objName)
-			: info(data)
-			, moduleName(modName)
-			, objectName(objName)
+			: info(std::move(data))
+			, moduleName(std::move(modName))
+			, objectName(std::move(objName))
 		{}
 
 		Module(Module&& other)


### PR DESCRIPTION
Module::Module(Module&&) was improperly defined without std::move() on the parameters, which would result in a crash if any of the DataPtr<> in the Module spanned non-adjacent pages. Also fixed email address.
